### PR TITLE
Ticket 602 – Implement Neutral Monochromatic Color Scheme

### DIFF
--- a/manual-tests.txt
+++ b/manual-tests.txt
@@ -61,4 +61,26 @@ Use `./build.sh` to build CiCo and `./run.sh` to run it if using the command lin
 ## Expected results
 * Should display "Developer" for the user name.
 
+[Ticket 602] Verify neutral monochromatic color scheme
+
+- TEST STEPS:
+1. Build and run CiCo.
+2. Observe the Main panel background color.
+3. Observe the Status panel background color.
+4. Observe the Error panel background color.
+5. Verify all labels (directive, user, state, error reason) use white text.
+6. Verify the text field uses a light gray background with black text.
+7. Verify all buttons use gray or dark gray backgrounds with white text.
+8. Confirm no bright or saturated colors
+   (e.g., cyan, green, magenta, red, blue, yellow) remain.
+9. Evaluate readability and contrast of all text and UI elements.
+
+- EXPECTED RESULTS:
+- All panels use neutral gray or dark gray backgrounds.
+- All labels use white text.
+- The text field uses a light gray background with black text.
+- All buttons use gray or dark gray backgrounds with white text.
+- No bright or saturated colors appear anywhere in the UI.
+- The overall color scheme appears neutral, professional, and visually consistent.
+
 

--- a/src/edu/cvtc/itsd/Main.java
+++ b/src/edu/cvtc/itsd/Main.java
@@ -241,13 +241,13 @@ public class Main {
     panelMain.setMinimumSize(new Dimension(320, 240));
     panelMain.setPreferredSize(new Dimension(640, 480));
     panelMain.setMaximumSize(new Dimension(640, 480));
-    panelMain.setBackground(Color.black);
+    panelMain.setBackground(Color.DARK_GRAY);
 
     panelMain.add(Box.createVerticalGlue());
     JLabel labelDirective = new JLabel("Scan card", JLabel.LEADING);
     labelDirective.setFont(fontMain);
     labelDirective.setAlignmentX(JComponent.CENTER_ALIGNMENT);
-    labelDirective.setForeground(Color.cyan);
+    labelDirective.setForeground(Color.WHITE);
     panelMain.add(labelDirective);
 
     fieldNumber = new JTextField();
@@ -256,14 +256,15 @@ public class Main {
     fieldNumber.setPreferredSize(new Dimension(200, 32));
     fieldNumber.setMaximumSize(new Dimension(200, 32));
     fieldNumber.setAlignmentX(JComponent.CENTER_ALIGNMENT);
-    fieldNumber.setBackground(Color.green);
-    fieldNumber.setForeground(Color.magenta);
+    fieldNumber.setBackground(Color.LIGHT_GRAY);
+    fieldNumber.setForeground(Color.BLACK);
     panelMain.add(fieldNumber);
 
     JButton updateButton = new JButton("Update");
     updateButton.setAlignmentX(JComponent.CENTER_ALIGNMENT);
     updateButton.addActionListener(new Update());
-    updateButton.setForeground(Color.green);
+    updateButton.setForeground(Color.WHITE);
+    updateButton.setBackground(Color.GRAY);
     panelMain.add(updateButton);
 
     panelMain.add(Box.createVerticalGlue());
@@ -274,19 +275,19 @@ public class Main {
     panelStatus.setMinimumSize(new Dimension(320, 240));
     panelStatus.setPreferredSize(new Dimension(640, 480));
     panelStatus.setMaximumSize(new Dimension(640, 480));
-    panelStatus.setBackground(Color.blue);
+    panelStatus.setBackground(Color.GRAY);
 
     panelStatus.add(Box.createVerticalGlue());
     labelUser = new JLabel("Registrant", JLabel.LEADING);
     labelUser.setFont(fontMain);
     labelUser.setAlignmentX(JComponent.CENTER_ALIGNMENT);
-    labelUser.setForeground(Color.yellow);
+    labelUser.setForeground(Color.WHITE);
     panelStatus.add(labelUser);
 
     labelState = new JLabel("updated", JLabel.LEADING);
     labelState.setFont(fontMain);
     labelState.setAlignmentX(JComponent.CENTER_ALIGNMENT);
-    labelState.setForeground(Color.magenta);
+    labelState.setForeground(Color.WHITE);
     panelStatus.add(labelState);
 
     panelStatus.add(Box.createVerticalGlue());
@@ -297,19 +298,20 @@ public class Main {
     panelError.setMinimumSize(new Dimension(320, 240));
     panelError.setPreferredSize(new Dimension(640, 480));
     panelError.setMaximumSize(new Dimension(640, 480));
-    panelError.setBackground(Color.red);
+    panelError.setBackground(Color.GRAY);
 
     panelError.add(Box.createVerticalGlue());
     labelReason = new JLabel("", JLabel.LEADING);
     labelReason.setFont(fontMain);
     labelReason.setAlignmentX(JComponent.CENTER_ALIGNMENT);
-    labelReason.setForeground(Color.yellow);
+    labelReason.setForeground(Color.WHITE);
     panelError.add(labelReason);
 
     buttonAcknowledge = new JButton("OK");
     buttonAcknowledge.addActionListener(handler);
     buttonAcknowledge.setAlignmentX(JComponent.CENTER_ALIGNMENT);
-    buttonAcknowledge.setForeground(Color.red);
+    buttonAcknowledge.setBackground(Color.DARK_GRAY);
+    buttonAcknowledge.setForeground(Color.WHITE);
     panelError.add(buttonAcknowledge);
     panelError.add(Box.createVerticalGlue());
 

--- a/to-accept.txt
+++ b/to-accept.txt
@@ -1,0 +1,1 @@
+imerkel


### PR DESCRIPTION
This pull request completes Ticket 602 by updating the CiCo application's UI to use a neutral, professional monochromatic color scheme.

Changes include:
- Replaced saturated colors with neutral grays, whites, and blacks
- Updated panel backgrounds, label colors, text field colors, and button styles
- Ensured consistent readability and contrast across all UI elements
- Added a manual test to `manual-tests.txt` prior to making code changes
- Verified that the updated UI passes the new manual test

Both the manual test and the UI implementation are included in this PR.